### PR TITLE
Update README.md. asJson deprecated, use parseJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ val json = """
       "price": 19.95
     }
   }
-}""".asJson
+}""".parseJson
 ```
 
 All authors in this document are addressed by


### PR DESCRIPTION
Updated example to use parseJson instead of asJson.